### PR TITLE
fix: fix transformTokensToVariable

### DIFF
--- a/src/utils/css.ts
+++ b/src/utils/css.ts
@@ -1,5 +1,5 @@
 import type { DesignToken, PinceauContext } from '../types'
-import { transformTokensToVariable } from './$tokens'
+import {  resolveVariableFromPath } from './$tokens'
 import { DARK, INITIAL, LIGHT, referencesRegex } from './regexes'
 
 /**
@@ -91,7 +91,7 @@ export function resolveReferences(
 
       const tokenValue = typeof token === 'string' ? token : token?.variable || token?.value
 
-      if (!tokenValue) { return transformTokensToVariable(tokenPath) }
+      if (!tokenValue) { return resolveVariableFromPath(tokenPath) }
 
       return tokenValue as string
     },


### PR DESCRIPTION
Using this syntax {color.primary.400} when we set a computeStyle, pinceau checks to see if the theme exists in the current theme object and converts it to css variable mode if it does not，

Pinceau transformTokensToVariable using this method for CSS variable transformation, the problem is that in using this method, `resolveReferences` this method has been replace `{}`, Pass it to transformTokensToVariable parameter is `color. primary. 400` rather than `{color. Primary. 400}`

Therefore, it cannot be converted to css variables correctly
We can convert this directly using `resolveVariableFromPath`
